### PR TITLE
2.5.1

### DIFF
--- a/simple-dark-redux.user.css
+++ b/simple-dark-redux.user.css
@@ -3,7 +3,7 @@
 @namespace      userstyles.world/user/meow
 @homepageURL    https://github.com/dragonjpg/simple-dark-redux
 @supportURL     https://github.com/dragonjpg/simple-dark-redux/issues
-@version        2.5.0
+@version        2.5.1
 @description    A rewrite of the Simple Dark Theme. Includes Simple Dark Tweaks.
 @author         grr
 
@@ -909,7 +909,7 @@ clan-color-text-3 "Light Mode" <<<EOT
     color: var(--text-alt);
     border: 2px solid var(--borders-med-alt);
     outline: 2px solid var(--borders);
-    padding: 0.2em;
+    padding: 0.2em 0.2em 0.4em;
     background: linear-gradient(to bottom, var(--widget-med-alt) 0%, var(--widget-light-alt) 100%);
     border-radius: 10px;
 }
@@ -1198,7 +1198,8 @@ forum-color-text-3 "Light Mode" <<<EOT
     color: var(--text-alt);
 }
 /*colored text*\/
-.post:not(.post-admin) :is(.post-text-content, #topic-preview-text) :is(b, i, strong, em),
+.post:not(.post-admin) .post-text-content :is(b, i, strong, em),
+#topic-preview-text :is(b, i, strong, em),
 .post-text-signature :is(b, i, strong, em),
 :is(.post-text-content, #topic-preview-text) a :is(b, i, strong, em),
 :is(.post-text-content, .post-text-signature, #topic-preview-text) span[style*="color:"] :is(b, i, strong, em, u),
@@ -1755,6 +1756,8 @@ forum-override-fonts-2 "Allow" <<<EOT EOT;
     /*main content bgs*/
     .container {
         border-radius: 0;
+        /*z-index: 1;
+        position: relative;*/
     }
     
     .main, .contentcontainer {
@@ -1815,6 +1818,7 @@ forum-override-fonts-2 "Allow" <<<EOT EOT;
         border: 5px solid var(--bar);
         border-bottom: none;
         width: 295px;
+        z-index: 2;
     }
     #usertab::before {
         content: '';
@@ -2012,14 +2016,13 @@ forum-override-fonts-2 "Allow" <<<EOT EOT;
         background: var(--accent-five)
     }
     /*more buttons*/
-    .common-ui-button, .lair-pagination .lair-pagination-page, .common-pagination .common-pagination-page,
-    .common-ui-vertical-button-group, .common-js-pagination .common-pagination-page, .wws-carousel-navigation-status,
+    .common-ui-button, a.common-ui-button, .lair-pagination .lair-pagination-page, .common-pagination .common-pagination-page, .common-ui-vertical-button-group, .common-js-pagination .common-pagination-page, .wws-carousel-navigation-status,
     .sitewide-effort-navigation-item, .item-picker-pagination-pages, .dragon-picker-pagination-pages, .morphology-picker-pagination-pages {
         color: var(--button-text-dark);
         border: 2px solid var(--borders-med);
         background: linear-gradient(to bottom, var(--button-one) 0%, var(--button-two) 100%);
     }
-    .common-ui-button-disabled, .greybutton, .greybutton.stopbutton,
+    .common-ui-button-disabled, a.common-ui-button-disabled, .greybutton, .greybutton.stopbutton,
     .common-ui-vertical-button-group > .common-ui-button-disabled,
     .common-ui-vertical-button-group .common-ui-button-group .common-ui-button-disabled,
     .beigebutton.thingbutton:disabled,
@@ -2048,7 +2051,7 @@ forum-override-fonts-2 "Allow" <<<EOT EOT;
         min-width: 100px;
         width: auto;
     }
-    .common-pagination .common-pagination-page:hover, .common-js-pagination .common-pagination-page:hover, .common-pagination .common-pagination-page-space.common-pagination-page-space-hover:hover, .common-js-pagination .common-pagination-page-space.common-pagination-page-space-hover:hover,
+    a[class="common-ui-button"]:hover, .common-pagination .common-pagination-page:hover, .common-js-pagination .common-pagination-page:hover, .common-pagination .common-pagination-page-space.common-pagination-page-space-hover:hover, .common-js-pagination .common-pagination-page-space.common-pagination-page-space-hover:hover,
     .sitewide-effort-navigation-item:not(.sitewide-effort-navigation-item-current):hover,
     .item-picker-pagination-pages:hover, .dragon-picker-pagination-pages:hover, .morphology-picker-pagination-pages:hover {
         border-color: var(--borders-light);
@@ -6174,10 +6177,10 @@ text-shadow: -2px -2px 0px var(--shadow), -2px -1px 0px var(--shadow), -2px 0px 
     .post-admin .post-text-content, .post-admin .post-text-content li, .post-admin .post-text-content li span, .search-result-body.adminpost {
         color: var(--admin-text) !important;
     }
-    .post-admin .post-text-content a:not(.dragon-effect-controls-item), .post-admin .post-text-content a:not(.dragon-effect-controls-item) > *, .post-admin .post-text-content ul li::marker {
+    .post-admin .post-text-content a:not(.dragon-effect-controls-item, .pinglist-button-title), .post-admin .post-text-content a:not(.dragon-effect-controls-item, .pinglist-button-title) > *, .post-admin .post-text-content ul li::marker {
         color: var(--admin-link) !important;
     }
-    .post-admin .post-text-content a:not(.dragon-effect-controls-item):hover, .post-admin .post-text-content a:not(.dragon-effect-controls-item):focus, .post-admin .post-text-content a:not(.dragon-effect-controls-item):hover > *, .post-admin .post-text-content a:not(.dragon-effect-controls-item):focus > * {
+    .post-admin .post-text-content a:not(.dragon-effect-controls-item, .pinglist-button-title):hover, .post-admin .post-text-content a:not(.dragon-effect-controls-item, .pinglist-button-title):focus, .post-admin .post-text-content a:not(.dragon-effect-controls-item, .pinglist-button-title):hover > *, .post-admin .post-text-content a:not(.dragon-effect-controls-item, .pinglist-button-title):focus > * {
         color: var(--admin-link-hover) !important;
     }
     .post-admin .post-text-content b, .post-admin .post-text-content strong {

--- a/simple-dark-redux.user.css
+++ b/simple-dark-redux.user.css
@@ -1099,16 +1099,15 @@ bio-color-text-3 "Light Mode" <<<EOT
 EOT;
 }
 
-@advanced dropdown forum-color-text "Forum Post Content & Previewer" {
+@advanced dropdown forum-color-text "PMs & Forum Posts" {
 forum-color-text-1 "Dark Mode (Disallow User-set Colors)" <<<EOT
-:is(.post-text-content, .post-text-signature, #topic-preview-text) span[style*="color:"]:not(span[style*="transparent"], .bbcode_spoiler) {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) span[style*="color:"]:not(span[style*="transparent"], .bbcode_spoiler) {
     color: var(--text) !important;
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) span[style*="transparent"] * {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) span[style*="transparent"] * {
     color: transparent !important;
 }
-#topic-preview-text a span[style*="color:"]:not(span[style*="transparent"]),
-.post-text a span[style*="color:"]:not(span[style*="transparent"]) {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) a span[style*="color:"]:not(span[style*="transparent"]) {
     color: inherit !important;
 }
 
@@ -1127,7 +1126,8 @@ forum-color-text-2 "Dark Mode (Allow User-set Colors)" <<<EOT
 EOT;
 forum-color-text-3 "Light Mode" <<<EOT
 /*general - we do not directly overwrite most vars to avoid breaking widgets *\/
-:is(.post-text-content, .post-text-signature, #topic-preview-text) {
+:is(.post-text-content, .post-text-signature, #topic-preview-text),
+#msg-preview-text, #msg-text {
     --text-alt: #000;
     --text-med: #555;
     --post-text: var(--text-alt);
@@ -1166,35 +1166,40 @@ forum-color-text-3 "Light Mode" <<<EOT
     --widget-med-bg: #fff;
     --widget-med-alt: #faf9f7;
 }
-#topic-preview-text {
+#topic-preview-text, #msg-preview-text, #msg-show {
     background-color: #fff;
 }
+/*fix pm attachments label*\/
+#msg-items > p {
+    --text-alt: #000;
+    color: var(--text-alt);
+}
 /*link colors*\/
-:is(.post-text-content, .post-text-signature, #topic-preview-text) .gamedb-bbcode,
-:is(.post-text-content, .post-text-signature, #topic-preview-text) .pinglist-bbcode {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) .gamedb-bbcode,
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) .pinglist-bbcode {
     --link: var(--link-alt);
     --link-hover: var(--link-hover-alt);
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) a {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) a {
     color: var(--link-alt);
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) a:hover,
-:is(.post-text-content, .post-text-signature, #topic-preview-text) a:focus,
-:is(.post-text-content, .post-text-signature, #topic-preview-text) a:focus-within,
-:is(.post-text-content, .post-text-signature, #topic-preview-text) a:hover :is(b, strong, i, em) {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) a:hover,
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) a:focus,
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) a:focus-within,
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) a:hover :is(b, strong, i, em) {
     color: var(--link-hover-alt);
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) :is(.outfit-image, .scry-image, .forum-map-widget-frame, .dragon-effect-frame) a {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) :is(.outfit-image, .scry-image, .forum-map-widget-frame, .dragon-effect-frame) a {
     color: var(--link);
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) :is(.outfit-image, .scry-image, .forum-map-widget-frame, .dragon-effect-frame) a:hover,
-:is(.post-text-content, .post-text-signature, #topic-preview-text) :is(.outfit-image, .scry-image, .forum-map-widget-frame, .dragon-effect-frame) a:focus, 
-:is(.post-text-content, .post-text-signature, #topic-preview-text) :is(.outfit-image, .scry-image, .forum-map-widget-frame, .dragon-effect-frame) a:focus-within {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) :is(.outfit-image, .scry-image, .forum-map-widget-frame, .dragon-effect-frame) a:hover,
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) :is(.outfit-image, .scry-image, .forum-map-widget-frame, .dragon-effect-frame) a:focus, 
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) :is(.outfit-image, .scry-image, .forum-map-widget-frame, .dragon-effect-frame) a:focus-within {
     color: var(--link-hover);
 }
 /*columns*\/
-:is(.post-text-content, .post-text-signature, #topic-preview-text) td,
-:is(.post-text-content, .post-text-signature, #topic-preview-text) th {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) td,
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) th {
     color: var(--text-alt);
 }
 /*colored text*\/
@@ -1202,35 +1207,35 @@ forum-color-text-3 "Light Mode" <<<EOT
 #topic-preview-text :is(b, i, strong, em),
 .post-text-signature :is(b, i, strong, em),
 :is(.post-text-content, #topic-preview-text) a :is(b, i, strong, em),
-:is(.post-text-content, .post-text-signature, #topic-preview-text) span[style*="color:"] :is(b, i, strong, em, u),
-.post-edited em {
+:is(.post-text-content, .post-text-signature, #topic-preview-text) span[style*="color:"] :is(b, i, strong, em, u), .post-edited em, #msg-text :is(b, i, strong, em), #msg-text a :is(b, i, strong, em),
+#msg-preview-text :is(b, i, strong, em), #msg-preview-text a :is(b, i, strong, em){
     color: inherit;
 }
 /*bbcode quotes & code tags*\/
-:is(.post-text-content, .post-text-signature, #topic-preview-text) :is(.bbcode_quote, .bbcode_code) {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) :is(.bbcode_quote, .bbcode_code) {
     border-color: var(--quote-header);
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) :is(div.bbcode_quote_head, div.bbcode_code_head) {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) :is(div.bbcode_quote_head, div.bbcode_code_head) {
     --tooltip-header: var(--quote-header);
     --borders: --quote-header;
     --text: #fff;
     --link: #fff;
     --link-hover: #fff;
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) :is(div.bbcode_quote_head, div.bbcode_code_head) a {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) :is(div.bbcode_quote_head, div.bbcode_code_head) a {
     color: inherit !important;
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) :is(div.bbcode_quote_body, div.bbcode_code_body) {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) :is(div.bbcode_quote_body, div.bbcode_code_body) {
     background-color: #f8f3d4;
     color: var(--text-alt);
 }
 /*hiddens*\/
-:is(.post-text-content, .post-text-signature, #topic-preview-text) .forum-hidden-header {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) .forum-hidden-header {
     --strong: #fff;
     --section: var(--fr-red);
     border-color: var(--fr-red);
 }
-:is(.post-text-content, .post-text-signature, #topic-preview-text) .forum-hidden {
+:is(.post-text-content, .post-text-signature, #topic-preview-text, #msg-text, #msg-preview-text) .forum-hidden {
     background: #fff;
     border-color: #cab1b1;
 }
@@ -6417,7 +6422,6 @@ text-shadow: -2px -2px 0px var(--shadow), -2px -1px 0px var(--shadow), -2px 0px 
         border: 1px solid rgb(var(--warning));
         color: var(--warning-text);
     }
-    /*[[forum-color-text]]*/
     
     /*[[stickyposter]]*/
     
@@ -6681,13 +6685,14 @@ text-shadow: -2px -2px 0px var(--shadow), -2px -1px 0px var(--shadow), -2px 0px 
         margin-bottom: 15px;
     }
     #msg-show span#msg-avatar,
-    #msg-preview #body span:first-child {
+    #msg-preview #body > span:first-child {
         background: linear-gradient(to bottom, var(--section) 0%, var(--widget) 50%);
         grid-row: 1 / 3;
     }
     #msg-editor > div[style*="margin-bottom:5px; position:relative; height:20px;"] {
         height: auto !important;
     }
+    /*man the message preview is messed up huh */
     #msg-preview #header {
         padding-left: 5px;
         box-sizing: border-box;
@@ -6700,19 +6705,31 @@ text-shadow: -2px -2px 0px var(--shadow), -2px -1px 0px var(--shadow), -2px 0px 
         grid-template-columns: 130px auto;
         overflow: hidden;
     }
-    #msg-preview #body span:first-child {
-        margin-top: 0;
-        padding-top: 15px;
-        box-sizing:border-box;
-    }
     #msg-preview #body #preview-header {
         width: 100%;
         margin: 0;
     }
     #msg-preview-text {
         width: 100%;
+        padding: 14px;
+        box-sizing: border-box;
+        min-height: 150px;
+    }
+    #msg-preview #body span:first-child {
+        margin: 0;
     }
     #msg-preview #body span:last-child {
+        background: none;
+        padding: 0;
+        width: auto;
+        min-height: unset;
+    }
+    #msg-preview #body > span:first-child {
+        margin-top: 0;
+        padding-top: 15px;
+        box-sizing:border-box;
+    }
+    #msg-preview #body > span:last-child {
         background-image: none;
         border-left: 1px solid var(--borders);
         box-sizing: border-box;
@@ -6732,6 +6749,9 @@ text-shadow: -2px -2px 0px var(--shadow), -2px -1px 0px var(--shadow), -2px 0px 
         width: 100%;
         padding: 10px 5px;
     }
+    
+    /*light mode*/
+    /*[[forum-color-text]]*/
 }
 @-moz-document regexp("(http|https):\\/\\/(|www\\.|www1\\.)flightrising\\.com\\/main\\.php\\?p=battle.*"), regexp("(http|https):\\/\\/(|www\\.|www1\\.)flightrising\\.com\\/coliseum.*") {
     /* Coliseum */


### PR DESCRIPTION
- Expanded Light Mode setting for Forum Posts/Previewer to also affect PMs/PM previewer.
- Changed label of **Forum Post Content & Previewer** option to **PMs & Forum Posts** to reflect that it affects both now.
-  Small tweaks to the PM previewer styles that are part of the site's base CSS and makes PM previews look weird. This _should_ make them look consistent with what is actually sent to the other person, especially if you use color tags in your PMs.
- Styled the "a" tag buttons used for selecting an option to preview when previewing effects in the game database
- Minor fixes for some widget colors in admin posts